### PR TITLE
fix(messages): default max tokens to 4096 for custom models

### DIFF
--- a/src/messages/claude_model.rs
+++ b/src/messages/claude_model.rs
@@ -38,6 +38,8 @@ pub enum ClaudeModel {
     Claude45Haiku20251001,
     // Claude 4.5 Opus
     Claude45Opus20251101,
+    // Claude 4.6 Opus
+    Claude46Opus,
     Other(String),
 }
 impl Default for ClaudeModel {
@@ -91,6 +93,9 @@ impl Display for ClaudeModel {
             | ClaudeModel::Claude45Opus20251101 => {
                 write!(f, "claude-opus-4-5-20251101")
             },
+            | ClaudeModel::Claude46Opus => {
+                write!(f, "claude-opus-4-6")
+            },
             | ClaudeModel::Other(name) => {
                 write!(f, "{name}")
             },
@@ -114,6 +119,7 @@ impl ClaudeModel {
             | ClaudeModel::Claude45Sonnet20250929 => 64000,
             | ClaudeModel::Claude45Haiku20251001 => 8192,
             | ClaudeModel::Claude45Opus20251101 => 64000,
+            | ClaudeModel::Claude46Opus => 128000,
             | ClaudeModel::Other(_) => 0,
         }
     }
@@ -145,7 +151,8 @@ impl_enum_string_serialization_with_other!(
     Claude41Sonnet20250805 => "claude-sonnet-4-1-20250805",
     Claude45Sonnet20250929 => "claude-sonnet-4-5-20250929",
     Claude45Haiku20251001 => "claude-haiku-4-5-20251001",
-    Claude45Opus20251101 => "claude-opus-4-5-20251101";
+    Claude45Opus20251101 => "claude-opus-4-5-20251101",
+    Claude46Opus => "claude-opus-4-6";
     Other(String)
 );
 

--- a/src/messages/max_tokens.rs
+++ b/src/messages/max_tokens.rs
@@ -72,9 +72,12 @@ impl MaxTokens {
     }
 
     /// Creates a new maximum number of tokens for the model.
+    /// For custom models (where max_tokens is unknown), defaults to 4096.
     pub fn from_model(model: ClaudeModel) -> Self {
+        let model_max = model.max_tokens();
         Self {
-            value: model.max_tokens(),
+            // Use 4096 as default for custom models (where max_tokens returns 0)
+            value: if model_max == 0 { 4096 } else { model_max },
         }
     }
 }


### PR DESCRIPTION
For custom models where the maximum token count is unknown (i.e., 0 is returned), use 4096 as a sensible default to avoid issues with token validation and model usage.